### PR TITLE
Dependabot と GitHub Actions 更新を導入する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10.x'
+          python-version: '3.10'
           architecture: 'x64'
       - name: install lint tools
         run: pip install flake8==3.7.9 mypy==1.7.1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -31,8 +31,8 @@ jobs:
       - name: flake8
         run: |
           cd ../
-          flake8 --config=blender2pmxem/.pep8 blender2pmxem
+          flake8 --config=blender2pmxemn/.pep8 blender2pmxemn
       - name: mypy
         run: |
           cd ../
-          mypy --no-incremental --ignore-missing-imports blender2pmxem
+          mypy --no-incremental --ignore-missing-imports blender2pmxemn

--- a/.github/workflows/packageing_and_upload.yml
+++ b/.github/workflows/packageing_and_upload.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: zip
         run: zip -r blender2pmxem.zip . -x  '/*.git/*' '/*.github/*' '/*__pycache_/*' '/*.gitignore' '/*.pep8' '/*tests/*' '/*.editorconfig'
       - name: upload artifact
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: package
           path: blender2pmxem.zip

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10.x'
+          python-version: '3.10'
           architecture: 'x64'
       - name: install required package
         run: pip install mathutils

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,9 +24,5 @@ jobs:
         with:
           python-version: '3.10'
           architecture: 'x64'
-      - name: install system package
-        run: sudo apt-get update && sudo apt-get install -y libeigen3-dev
-      - name: install required package
-        run: pip install mathutils
       - name: unittest discoverly
         run: python -m unittest discover tests/

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           python-version: '3.10'
           architecture: 'x64'
+      - name: install system package
+        run: sudo apt-get update && sudo apt-get install -y libeigen3-dev
       - name: install required package
         run: pip install mathutils
       - name: unittest discoverly


### PR DESCRIPTION
## 概要
- Dependabot を追加して GitHub Actions の更新追従を行えるようにします
- 古い action 参照を現行の安定版へ更新します

## 変更内容
- .github/dependabot.yml を追加
- ctions/checkout を v4 へ更新
- ctions/setup-python を v5 へ更新
- ctions/upload-artifact を v4 へ更新
- workflow 内の Python 指定表記を整理

## 背景
Blender 5.1 対応を進める前提として、最低限のセキュリティ追従と CI メンテナンス基盤を先に整えておきます。

## 補足
機能面の Blender 5.1 対応は別ブランチで継続します。
