### PR TITLE
unittest の mathutils 依存を CI で解消する

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,5 +24,7 @@ jobs:
         with:
           python-version: '3.10'
           architecture: 'x64'
+      - name: install required package
+        run: pip install mathutils
       - name: unittest discoverly
         run: python -m unittest discover tests/

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           python-version: '3.10'
           architecture: 'x64'
+      - name: install system dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libeigen3-dev
       - name: install required package
         run: pip install mathutils
       - name: unittest discoverly

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,12 +22,8 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.13'
           architecture: 'x64'
-      - name: install system dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libeigen3-dev
       - name: install required package
         run: pip install mathutils
       - name: unittest discoverly


### PR DESCRIPTION
## 概要
- unittest を 目的であるblender5.1.0で利用されている`Python 3.13` で実行するようにします
- unittest 実行前に `mathutils` を導入します
- この依存は fork 元を含めて現行コードで使われているため、テスト削除ではなく CI 側で吸収する方針です

## 背景
- PR #9, #10, #11 はいずれも `Run Unittest` で失敗していました
- 原因は `mathutils` が無いことでした
- さらに `mathutils 5.1.0` は `Python 3.10` だとソースビルドで失敗したため、wheel を使いやすい `Python 3.13` に寄せています

## 検証
- ローカルで GitHub Actions は実行していません
- 検証は PR 上の GitHub Actions を使います